### PR TITLE
Fix issues with tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 bumpversion
-mock
 twine

--- a/subx/tests/test_subx.py
+++ b/subx/tests/test_subx.py
@@ -2,8 +2,8 @@
 
 import subprocess
 import unittest
+from unittest import mock
 
-import mock
 import subx
 
 
@@ -19,7 +19,8 @@ class Test(unittest.TestCase):
 
     def test_subprocess_result_call__read_stdout(self):
         result = subx.SubprocessResult.call(['cat', '/etc/fstab'])
-        self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
+        with open('/etc/fstab', 'rb') as fd:
+            self.assertEqual(fd.read(), result.stdout)
         self.assertEqual(0, result.ret)
         self.assertEqual(b'', result.stderr)
         self.assertEqual(['cat', '/etc/fstab'], result.cmd)
@@ -33,13 +34,15 @@ class Test(unittest.TestCase):
     def test_subprocess_result_call__read_sterr_and_stdout(self):
         result = subx.SubprocessResult.call(['cat', '/etc/fstab', '/file/which/does/not/exist'],
                                             env=dict(LANG='C'))
-        self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
+        with open('/etc/fstab', 'rb') as fd:
+            self.assertEqual(fd.read(), result.stdout)
         self.assertEqual(1, result.ret)
         self.assertEqual(b'cat: /file/which/does/not/exist: No such file or directory\n', result.stderr)
 
     def test_assert_zero_exit_status__ok(self):
         result = subx.call(['cat', '/etc/fstab'], assert_zero_exit_status=True)
-        self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
+        with open('/etc/fstab', 'rb') as fd:
+            self.assertEqual(fd.read(), result.stdout)
         self.assertEqual(0, result.ret)
         self.assertEqual(b'', result.stderr)
         self.assertEqual(['cat', '/etc/fstab'], result.cmd)
@@ -59,7 +62,8 @@ class Test(unittest.TestCase):
 
     def test_warn_on_non_zero_exist_status__ok(self):
         result = subx.call(['cat', '/etc/fstab'], warn_on_non_zero_exist_status=True)
-        self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
+        with open('/etc/fstab', 'rb') as fd:
+            self.assertEqual(fd.read(), result.stdout)
         self.assertEqual(0, result.ret)
         self.assertEqual(b'', result.stderr)
         self.assertEqual(['cat', '/etc/fstab'], result.cmd)


### PR DESCRIPTION
This PR fixes some warnings which are visible when running tests with *ResourceWarning*s enabled (for example when using the stdlib *unittest* test runner or when setting `PYTHONWARNINGS=error::ResourceWarning` explicitly). Additionally, the requirement on *mock* has been dropped, as for the supported Python versions >= 3.7 `unittest.mock` will always be available.

Some details on the warnings:

```python3
stefan@localhost:~/code/subx/subx/tests> python -m unittest test_subx.py 
./home/stefan/code/subx/subx/tests/test_subx.py:42: ResourceWarning: unclosed file <_io.BufferedReader name='/etc/fstab'>
  self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
....../usr/lib64/python3.7/traceback.py:220: ResourceWarning: unclosed file <_io.BufferedReader name='/dev/null'>
  tb.tb_frame.clear()
./home/stefan/code/subx/subx/tests/test_subx.py:22: ResourceWarning: unclosed file <_io.BufferedReader name='/etc/fstab'>
  self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
../home/stefan/code/subx/subx/tests/test_subx.py:36: ResourceWarning: unclosed file <_io.BufferedReader name='/etc/fstab'>
  self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
....../home/stefan/code/subx/subx/tests/test_subx.py:62: ResourceWarning: unclosed file <_io.BufferedReader name='/etc/fstab'>
  self.assertEqual(open('/etc/fstab', 'rb').read(), result.stdout)
.
----------------------------------------------------------------------
Ran 17 tests in 0.035s

OK
```

After fixing the obvious `/etc/fstab` issues, further dig into the `/dev/null` one:

```python3
stefan@localhost:~/code/subx/subx/tests> PYTHONTRACEMALLOC=25 python -m unittest test_subx.py --verbose
test_assert_zero_exit_status__non_zero (test_subx.Test) ... ok
test_assert_zero_exit_status__ok (test_subx.Test) ... ok
test_call (test_subx.Test) ... ok
test_call_with_data (test_subx.Test) ... ok
test_redirect_stderr_to_stdout (test_subx.Test) ... ok
test_repr_of_subprocess_result_is_7bit_ascii__bytestring (test_subx.Test) ... ok
test_subprocess_result__repr (test_subx.Test) ... ok
test_subprocess_result_call__command_which_does_not_exist (test_subx.Test) ... /usr/lib64/python3.7/traceback.py:220: ResourceWarning: unclosed file <_io.BufferedReader name='/dev/null'>
  tb.tb_frame.clear()
Object allocated at (most recent call first):
  File "/home/stefan/code/venv/lib/python3.7/site-packages/subx-2020.42.0-py3.7.egg/subx/__init__.py", lineno 89
  File "/usr/lib64/python3.7/unittest/case.py", lineno 178
    callable_obj(*args, **kwargs)
  File "/usr/lib64/python3.7/unittest/case.py", lineno 733
    return context.handle('assertRaises', args, kwargs)
  File "/home/stefan/code/subx/subx/tests/test_subx.py", lineno 18
    self.assertRaises(OSError, subx.SubprocessResult.call, ['command-which-does-not-exist'])
  File "/usr/lib64/python3.7/unittest/case.py", lineno 605
    testMethod()
  File "/usr/lib64/python3.7/unittest/case.py", lineno 653
    return self.run(*args, **kwds)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 122
    test(result)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 84
    return self.run(*args, **kwds)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 122
    test(result)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 84
    return self.run(*args, **kwds)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 122
    test(result)
  File "/usr/lib64/python3.7/unittest/suite.py", lineno 84
    return self.run(*args, **kwds)
  File "/usr/lib64/python3.7/unittest/runner.py", lineno 176
    test(result)
  File "/usr/lib64/python3.7/unittest/main.py", lineno 256
    self.result = testRunner.run(self.test)
  File "/usr/lib64/python3.7/unittest/main.py", lineno 95
    self.runTests()
  File "/usr/lib64/python3.7/unittest/__main__.py", lineno 18
    main(module=None)
  File "/usr/lib64/python3.7/runpy.py", lineno 85
    exec(code, run_globals)
  File "/usr/lib64/python3.7/runpy.py", lineno 193
    "__main__", mod_spec)
ok
test_subprocess_result_call__read_stdout (test_subx.Test) ... ok
test_subprocess_result_call__read_sterr (test_subx.Test) ... ok
test_subprocess_result_call__read_sterr_and_stdout (test_subx.Test) ... ok
test_subx_called_with_incorrect__list_was_ommitted (test_subx.Test) ... ok
test_subx_failure_without_stderr (test_subx.Test) ... ok
test_subx_with_shell_is_true (test_subx.Test) ... ok
test_sudo_password_prompt_does_not_wait_for_ever (test_subx.Test) ... ok
test_warn_on_non_zero_exist_status__non_zero (test_subx.Test) ... ok
test_warn_on_non_zero_exist_status__ok (test_subx.Test) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.040s

OK
```